### PR TITLE
Add option to change report interval

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,3 +1,4 @@
+---
 extends: default
 
 rules:

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ earlyoom_installation_destination: /usr/bin
 
 earlyoom_minimum_memory_percent: 10
 earlyoom_minimum_swap_percent: 5
+earlyoom_memory_report_interval: 60 # in seconds
 ```
 
 Requirements

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,4 +7,4 @@ earlyoom_installation_destination: /usr/bin
 
 earlyoom_minimum_memory_percent: 10
 earlyoom_minimum_swap_percent: 5
-earlyoom_memory_report_interval: 60
+earlyoom_memory_report_interval: 60 # in seconds

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,4 +7,4 @@ earlyoom_installation_destination: /usr/bin
 
 earlyoom_minimum_memory_percent: 10
 earlyoom_minimum_swap_percent: 5
-earlyoom_memory_report_interval: 60 # in seconds
+earlyoom_memory_report_interval: 60  # in seconds

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,3 +7,4 @@ earlyoom_installation_destination: /usr/bin
 
 earlyoom_minimum_memory_percent: 10
 earlyoom_minimum_swap_percent: 5
+earlyoom_memory_report_interval: 60

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,7 +30,11 @@
     service_list:
       - name: earlyoom
         description: Early Out Of Memory Killer
-        start_command: /usr/bin/earlyoom -r {{ earlyoom_memory_report_interval }} -m {{ earlyoom_minimum_memory_percent }} -s {{ earlyoom_minimum_swap_percent }}
+        start_command: >-
+          /usr/bin/earlyoom
+          -r {{ earlyoom_memory_report_interval }}
+          -m {{ earlyoom_minimum_memory_percent }}
+          -s {{ earlyoom_minimum_swap_percent }}
         status_pattern: earlyoom
 
 - name: start and enable earlyoom

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,7 +30,7 @@
     service_list:
       - name: earlyoom
         description: Early Out Of Memory Killer
-        start_command: /usr/bin/earlyoom -r 60 -m {{ earlyoom_minimum_memory_percent }} -s {{ earlyoom_minimum_swap_percent }}
+        start_command: /usr/bin/earlyoom -r {{ earlyoom_memory_report_interval }} -m {{ earlyoom_minimum_memory_percent }} -s {{ earlyoom_minimum_swap_percent }}
         status_pattern: earlyoom
 
 - name: start and enable earlyoom


### PR DESCRIPTION
---
name: Pull request
about: Add option to change report interval

---

**Describe the change**
This PR adds an option to specify the report interval value, which was previously hard-coded to 60 seconds. I like to reduce the reporting interval so that earlyoom can respond in a timely manner in case an application starts eating up memory very quickly.
